### PR TITLE
Przypisano nazwę do pola agreementsDir w JavaStartProperties.java

### DIFF
--- a/src/main/java/pl/javastart/bootcamp/config/security/SecurityConfig.java
+++ b/src/main/java/pl/javastart/bootcamp/config/security/SecurityConfig.java
@@ -82,6 +82,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         if (environment.acceptsProfiles(Profiles.of("dev"))) {
             http.headers().frameOptions().disable();
         }
+        if (environment.acceptsProfiles(Profiles.of("prod"))) {
+            http.headers().frameOptions().sameOrigin();
+        }
     }
 
     @Bean

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,5 +1,6 @@
 spring.liquibase.contexts=dev
 javastart.fullDomainAddress=http://localhost:8080
+javastart.agreements-dir=/sample/agreements
 javastart.googleCalendarSyncEnabled=false
 spring.datasource.username=javastart
 spring.datasource.password=javastart123

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,5 @@
 spring.liquibase.contexts=dev
 javastart.fullDomainAddress=http://localhost:8080
-javastart.agreements-dir=/sample/agreements
 javastart.googleCalendarSyncEnabled=false
 spring.datasource.username=javastart
 spring.datasource.password=javastart123


### PR DESCRIPTION
Wartość null dla tego pola uniemożliwiała przypisanie nazwy ścieżki katalogu dla nowo powstającego pliku(umowy)
#7 
